### PR TITLE
Corrected typo in README: incorrect Safari version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Hey, do you support the `font-feature-settings` CSS property? Safari, look—I know you’re lying!
 
-This module is (somewhat intentionally) simple—you will find out whether or not `font-feature-settings` is supported, but not _what_ `font-feature-settings` specifically. Its primary target is Safari v9.2 and lower, which misrepresented whether or not it actually exposed `font-feature-settings` to front-end designers and developers.
+This module is (somewhat intentionally) simple—you will find out whether or not `font-feature-settings` is supported, but not _what_ `font-feature-settings` specifically. Its primary target is Safari v9.0 and lower, which misrepresented whether or not it actually exposed `font-feature-settings` to front-end designers and developers.
 
 ## Getting started
 


### PR DESCRIPTION
Safari 9.1 was first version to correctly report font features. Before that, it fibbed.
The confusion comes from Safari 9.1 appearing in iOS 9.3.
